### PR TITLE
[Feat] LockerRepository 구현

### DIFF
--- a/src/main/java/locker/model/Locker.java
+++ b/src/main/java/locker/model/Locker.java
@@ -6,11 +6,25 @@ public class Locker {
     private final Size size;
 
     public Locker(Long id, Size size) {
+        validateId(id);
+        validateSize(size);
         this.id = id;
         this.size = size;
     }
 
     public Long getId() {
         return id;
+    }
+
+    private void validateId(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Locker의 id는 null일 수 없습니다.");
+        }
+    }
+
+    private void validateSize(Size size) {
+        if (size == null) {
+            throw new IllegalArgumentException("Locker의 size는 null일 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/locker/model/Locker.java
+++ b/src/main/java/locker/model/Locker.java
@@ -9,4 +9,8 @@ public class Locker {
         this.id = id;
         this.size = size;
     }
+
+    public Long getId() {
+        return id;
+    }
 }

--- a/src/main/java/locker/repository/LockerRepository.java
+++ b/src/main/java/locker/repository/LockerRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 public interface LockerRepository {
 
     Locker getLocker(Long id);
-    void saveLocker(Locker locker);
+    Long saveLocker(Locker locker);
     List<Locker> getOccupiedLockers();
 }

--- a/src/main/java/locker/repository/LockerRepository.java
+++ b/src/main/java/locker/repository/LockerRepository.java
@@ -1,0 +1,12 @@
+package locker.repository;
+
+import locker.model.Locker;
+
+import java.util.List;
+
+public interface LockerRepository {
+
+    Locker getLocker(Long id);
+    void saveLocker(Locker locker);
+    List<Locker> getOccupiedLockers();
+}

--- a/src/main/java/locker/repository/MemoryLockerRepository.java
+++ b/src/main/java/locker/repository/MemoryLockerRepository.java
@@ -1,0 +1,12 @@
+package locker.repository;
+
+import locker.model.Locker;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+public class MemoryLockerRepository {
+
+    private final Map<Long, Locker> lockers = new ConcurrentSkipListMap<>(Comparator.comparingLong(id -> id));
+}

--- a/src/main/java/locker/repository/MemoryLockerRepository.java
+++ b/src/main/java/locker/repository/MemoryLockerRepository.java
@@ -3,10 +3,26 @@ package locker.repository;
 import locker.model.Locker;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
 
-public class MemoryLockerRepository {
+public class MemoryLockerRepository implements LockerRepository {
 
     private final Map<Long, Locker> lockers = new ConcurrentSkipListMap<>(Comparator.comparingLong(id -> id));
+
+    @Override
+    public Locker getLocker(Long id) {
+        return lockers.get(id);
+    }
+
+    @Override
+    public Long saveLocker(Locker locker) {
+        return lockers.put(locker.getId(), locker).getId();
+    }
+
+    @Override
+    public List<Locker> getOccupiedLockers() {
+        return List.of();
+    }
 }

--- a/src/main/java/locker/repository/MemoryLockerRepository.java
+++ b/src/main/java/locker/repository/MemoryLockerRepository.java
@@ -5,6 +5,7 @@ import locker.model.Locker;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 public class MemoryLockerRepository implements LockerRepository {
@@ -18,11 +19,12 @@ public class MemoryLockerRepository implements LockerRepository {
 
     @Override
     public Long saveLocker(Locker locker) {
-        return lockers.put(locker.getId(), locker).getId();
+        return Objects.requireNonNull(lockers.put(locker.getId(), locker)).getId();
     }
 
     @Override
     public List<Locker> getOccupiedLockers() {
+        // TODO : 사용 중인 Locker의 List를 반환하는 메서드 구현
         return List.of();
     }
 }


### PR DESCRIPTION
### LockerRepository 인터페이스
- 비우기, 채우기라는 용어는 비즈니스 로직에 포함시키는 것이 맞다고 판단하여 Repository 인터페이스는 조회, 저장 메서드로 구성하였다.
### MemoryLockerRepository 구현체
- 런타임 중에 Locker의 id에 따라 정렬 상태를 유지하고 동시성 문제를 예방하기 위해 ConcurrentSkipListMap 자료구조를 선택했다.

### TODO
- MemoryLockerRepository 구현체에서 getOccupiedLockers 메서드 구현하기